### PR TITLE
feat: Enable providing root directory to GUI app via command-line or drag-and-drop

### DIFF
--- a/src/PathLengthCheckerGUI/App.xaml
+++ b/src/PathLengthCheckerGUI/App.xaml
@@ -1,8 +1,7 @@
 ﻿<Application x:Class="PathLengthCheckerGUI.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             StartupUri="MainWindow.xaml">
-    <Application.Resources>
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+	<Application.Resources>
          
     </Application.Resources>
 </Application>

--- a/src/PathLengthCheckerGUI/App.xaml.cs
+++ b/src/PathLengthCheckerGUI/App.xaml.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 
 namespace PathLengthCheckerGUI
 {
@@ -17,6 +16,20 @@ namespace PathLengthCheckerGUI
 		public App() : base()
 		{
 			SetupUnhandledExceptionHandling();
+			Startup += App_Startup;
+		}
+
+		private void App_Startup(object sender, StartupEventArgs e)
+		{
+			var mainWindow = new MainWindow();
+
+			if (e.Args.Length > 0 && Directory.Exists(e.Args[0]))
+			{
+				mainWindow.txtRootDirectory.Text = e.Args[0];
+				mainWindow.btnGetPathLengths.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+			}
+
+			mainWindow.Show();
 		}
 
 		private void SetupUnhandledExceptionHandling()


### PR DESCRIPTION
For issue #36. Added feature to check path lengths for directories dropped onto PathLengthCheckerGUI.exe or passed via the command line.

Future idea: allow multiple directories, and support the same argument syntax as PathLengthChecker.exe, maybe using Program.ParseArgs