### PR TITLE
feat: Allow the GUI to handle command-line args like the console application

### DIFF
--- a/src/PathLengthChecker/ArgumentParser.cs
+++ b/src/PathLengthChecker/ArgumentParser.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PathLengthChecker
+{
+    public class ArgumentParser
+    {
+        /// <summary>
+        /// Parses the specified args array into a PathLengthSearchOptions object instance.
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static PathLengthSearchOptions ParseArgs(IEnumerable<string> args)
+        {
+            var searchOptions = new PathLengthSearchOptions();
+
+            foreach (var arg in args)
+            {
+                // Split the command-line arg on the equals sign.
+                var parameter = arg.Split("=".ToCharArray(), 2);
+                if (parameter.Count() < 2)
+                    throw new ArgumentException("All parameters must be of the format 'Parameter=Value'");
+
+                // Assign the Command and Value to temp variables for processing.
+                var command = parameter[0];
+                var value = parameter[1];
+
+                // Fill in the Search Options based on the Command.
+                switch (command)
+                {
+                    default:
+                        throw new ArgumentException("Unrecognized command: " + command);
+                    case "RootDirectory":
+                        searchOptions.RootDirectory = value;
+                        break;
+                    case "RootDirectoryReplacement":
+                        searchOptions.RootDirectoryReplacement = string.Equals(value, "null", StringComparison.InvariantCultureIgnoreCase) ? null : value;
+                        break;
+                    case "SearchOption":
+                        searchOptions.SearchOption = string.Equals("TopDirectory", value, StringComparison.InvariantCultureIgnoreCase) ? SearchOption.TopDirectoryOnly : SearchOption.AllDirectories;
+                        break;
+                    case "TypesToInclude":
+                        FileSystemTypes typesToInclude = FileSystemTypes.All;
+                        if (string.Equals("OnlyFiles", value, StringComparison.InvariantCultureIgnoreCase))
+                            typesToInclude = FileSystemTypes.Files;
+                        else if (string.Equals("OnlyDirectories", value, StringComparison.InvariantCultureIgnoreCase))
+                            typesToInclude = FileSystemTypes.Directories;
+
+                        searchOptions.TypesToGet = typesToInclude;
+                        break;
+                    case "SearchPattern":
+                        searchOptions.SearchPattern = value;
+                        break;
+                    case "MinLength":
+                        int minLength = -1;
+                        if (int.TryParse(value, out minLength))
+                            searchOptions.MinimumPathLength = minLength;
+                        break;
+                    case "MaxLength":
+                        int maxLength = -1;
+                        if (int.TryParse(value, out maxLength))
+                            searchOptions.MaximumPathLength = maxLength;
+                        break;
+                    case "Output":
+                        searchOptions.OutputType = value;
+                        break;
+                }
+            }
+
+            return searchOptions;
+        }
+
+    }
+}

--- a/src/PathLengthChecker/ArgumentParser.cs
+++ b/src/PathLengthChecker/ArgumentParser.cs
@@ -9,23 +9,23 @@ namespace PathLengthChecker
 {
     public class ArgumentParser
     {
-		public readonly static string ArgumentUsage =
-			"Parameters and example:\n" +
-			"RootDirectory= | Path to the directory to search through and list the paths of. Required.\n" +
-			"RootDirectoryReplacement=[null] | Path to replace the Root Directory with in the returned results. Specify 'null' to not replace the Root Directory. Default is null.\n" +
-			"SearchOption=[TopDirectory|All] | Specifies whether sub-directories should be searched or not. Default is All.\n" +
-			"TypesToInclude=[OnlyFiles|OnlyDirectories|All] | Specifies what types of paths should be returned in the results; files, directories, or both. Default is All.\n" +
-			"SearchPattern= | The pattern to match files against. '*' is a wildcard character. Default is '*' to match against everything.\n" +
-			"MinLength= | An integer indicating the minimum length that a path must contain in order to be returned in the results. Default is -1 to ignore this flag.\n" +
-			"MaxLength= | An integer indicating the maximum length that a path may have in order to be returned in the results. Default is -1 to ignore this flag.\n" +
-			"Output=[MinLength|MaxLength|All] | Indicates if you just want the Min/Max path length to be outputted, or if you want all of the paths to be outputted. Default is All.\n" +
-			"\n" +
-			"Example: PathLengthChecker.exe RootDirectory=\"C:\\MyDir\" TypesToInclude=OnlyFiles SearchPattern=*FindThis* MinLength=25";
+        public readonly static string ArgumentUsage =
+            "Parameters and example:\n" +
+            "RootDirectory= | Path to the directory to search through and list the paths of. Required.\n" +
+            "RootDirectoryReplacement=[null] | Path to replace the Root Directory with in the returned results. Specify 'null' to not replace the Root Directory. Default is null.\n" +
+            "SearchOption=[TopDirectory|All] | Specifies whether sub-directories should be searched or not. Default is All.\n" +
+            "TypesToInclude=[OnlyFiles|OnlyDirectories|All] | Specifies what types of paths should be returned in the results; files, directories, or both. Default is All.\n" +
+            "SearchPattern= | The pattern to match files against. '*' is a wildcard character. Default is '*' to match against everything.\n" +
+            "MinLength= | An integer indicating the minimum length that a path must contain in order to be returned in the results. Default is -1 to ignore this flag.\n" +
+            "MaxLength= | An integer indicating the maximum length that a path may have in order to be returned in the results. Default is -1 to ignore this flag.\n" +
+            "Output=[MinLength|MaxLength|All] | Indicates if you just want the Min/Max path length to be outputted, or if you want all of the paths to be outputted. Default is All.\n" +
+            "\n" +
+            "Example: PathLengthChecker.exe RootDirectory=\"C:\\MyDir\" TypesToInclude=OnlyFiles SearchPattern=*FindThis* MinLength=25";
 
-		/// <summary>
-		/// Parses the specified args array into a PathLengthSearchOptions object instance.
-		/// </summary>
-		public static PathLengthSearchOptions ParseArgs(IEnumerable<string> args)
+        /// <summary>
+        /// Parses the specified args array into a PathLengthSearchOptions object instance.
+        /// </summary>
+        public static PathLengthSearchOptions ParseArgs(IEnumerable<string> args)
         {
             var searchOptions = new PathLengthSearchOptions();
 

--- a/src/PathLengthChecker/ArgumentParser.cs
+++ b/src/PathLengthChecker/ArgumentParser.cs
@@ -3,17 +3,29 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using SearchOption = System.IO.SearchOption;
 
 namespace PathLengthChecker
 {
     public class ArgumentParser
     {
-        /// <summary>
-        /// Parses the specified args array into a PathLengthSearchOptions object instance.
-        /// </summary>
-        /// <param name="args"></param>
-        /// <returns></returns>
-        public static PathLengthSearchOptions ParseArgs(IEnumerable<string> args)
+		public readonly static string ArgumentUsage =
+			"Parameters and example:\n" +
+			"RootDirectory= | Path to the directory to search through and list the paths of. Required.\n" +
+			"RootDirectoryReplacement=[null] | Path to replace the Root Directory with in the returned results. Specify 'null' to not replace the Root Directory. Default is null.\n" +
+			"SearchOption=[TopDirectory|All] | Specifies whether sub-directories should be searched or not. Default is All.\n" +
+			"TypesToInclude=[OnlyFiles|OnlyDirectories|All] | Specifies what types of paths should be returned in the results; files, directories, or both. Default is All.\n" +
+			"SearchPattern= | The pattern to match files against. '*' is a wildcard character. Default is '*' to match against everything.\n" +
+			"MinLength= | An integer indicating the minimum length that a path must contain in order to be returned in the results. Default is -1 to ignore this flag.\n" +
+			"MaxLength= | An integer indicating the maximum length that a path may have in order to be returned in the results. Default is -1 to ignore this flag.\n" +
+			"Output=[MinLength|MaxLength|All] | Indicates if you just want the Min/Max path length to be outputted, or if you want all of the paths to be outputted. Default is All.\n" +
+			"\n" +
+			"Example: PathLengthChecker.exe RootDirectory=\"C:\\MyDir\" TypesToInclude=OnlyFiles SearchPattern=*FindThis* MinLength=25";
+
+		/// <summary>
+		/// Parses the specified args array into a PathLengthSearchOptions object instance.
+		/// </summary>
+		public static PathLengthSearchOptions ParseArgs(IEnumerable<string> args)
         {
             var searchOptions = new PathLengthSearchOptions();
 

--- a/src/PathLengthChecker/PathLengthChecker.csproj
+++ b/src/PathLengthChecker/PathLengthChecker.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ArgumentParser.cs" />
     <Compile Include="FileSystemTypes.cs" />
     <Compile Include="MinPathLengthGreaterThanMaxPathLengthException.cs" />
     <Compile Include="PathInfo.cs" />

--- a/src/PathLengthChecker/PathLengthSearchOptions.cs
+++ b/src/PathLengthChecker/PathLengthSearchOptions.cs
@@ -16,5 +16,11 @@
 		/// Specify a value of -1 to ignore the maximum path length.
 		/// </summary>
 		public int MaximumPathLength = -1;
+
+		/// <summary>
+		/// Indicates the type of result that is output once the search completes.
+		/// Valid values are MinLength, MaxLength, or All. Default is All
+		/// </summary>
+		public string OutputType = "All";
 	}
 }

--- a/src/PathLengthChecker/Program.cs
+++ b/src/PathLengthChecker/Program.cs
@@ -8,9 +8,6 @@ namespace PathLengthChecker
 {
 	class Program
 	{
-		// Used to tell what the console app should output.
-		private static string _output = string.Empty;
-
 		/// <summary>
 		/// Application entry point.
 		/// </summary>
@@ -20,19 +17,18 @@ namespace PathLengthChecker
 			try
 			{
 				// Fill the search options from the provided command line arguments.
-				var searchOptions = new PathLengthSearchOptions();
-				ParseArgs(args, ref searchOptions);
+				var searchOptions = ArgumentParser.ParseArgs(args);
 
-				if (string.Equals(_output, "MinLength", StringComparison.InvariantCultureIgnoreCase) ||
-					string.Equals(_output, "MaxLength", StringComparison.InvariantCultureIgnoreCase))
+				if (string.Equals(searchOptions.OutputType, "MinLength", StringComparison.InvariantCultureIgnoreCase) ||
+					string.Equals(searchOptions.OutputType, "MaxLength", StringComparison.InvariantCultureIgnoreCase))
 				{
 					// Do the search.
 					var paths = PathLengthChecker.GetPathsWithLengths(searchOptions, System.Threading.CancellationToken.None);
 
 					// Output the desired information (Min Path, Max Path, or All Paths).
-					if (string.Equals(_output, "MinLength", StringComparison.InvariantCultureIgnoreCase))
+					if (string.Equals(searchOptions.OutputType, "MinLength", StringComparison.InvariantCultureIgnoreCase))
 						Console.WriteLine(paths.Min(p => p.Length));
-					else if (string.Equals(_output, "MaxLength", StringComparison.InvariantCultureIgnoreCase))
+					else if (string.Equals(searchOptions.OutputType, "MaxLength", StringComparison.InvariantCultureIgnoreCase))
 						Console.WriteLine(paths.Max(p => p.Length));
 				}
 				else
@@ -56,61 +52,6 @@ namespace PathLengthChecker
 			}
 		}
 
-		private static void ParseArgs(IEnumerable<string> args, ref PathLengthSearchOptions searchOptions)
-		{
-			foreach (var arg in args)
-			{
-				// Split the command-line arg on the equals sign.
-				var parameter = arg.Split("=".ToCharArray(), 2);
-				if (parameter.Count() < 2)
-					throw new ArgumentException("All parameters must be of the format 'Parameter=Value'");
-
-				// Assign the Command and Value to temp variables for processing.
-				var command = parameter[0];
-				var value = parameter[1];
-
-				// Fill in the Search Options based on the Command.
-				switch (command)
-				{
-					default:
-						throw new ArgumentException("Unrecognized command: " + command);
-					case "RootDirectory":
-						searchOptions.RootDirectory = value;
-						break;
-					case "RootDirectoryReplacement":
-						searchOptions.RootDirectoryReplacement = string.Equals(value, "null", StringComparison.InvariantCultureIgnoreCase) ? null : value;
-						break;
-					case "SearchOption":
-						searchOptions.SearchOption = string.Equals("TopDirectory", value, StringComparison.InvariantCultureIgnoreCase) ? SearchOption.TopDirectoryOnly : SearchOption.AllDirectories;
-						break;
-					case "TypesToInclude":
-						FileSystemTypes typesToInclude = FileSystemTypes.All;
-						if (string.Equals("OnlyFiles", value, StringComparison.InvariantCultureIgnoreCase))
-							typesToInclude = FileSystemTypes.Files;
-						else if (string.Equals("OnlyDirectories", value, StringComparison.InvariantCultureIgnoreCase))
-							typesToInclude = FileSystemTypes.Directories;
-
-						searchOptions.TypesToGet = typesToInclude;
-						break;
-					case "SearchPattern":
-						searchOptions.SearchPattern = value;
-						break;
-					case "MinLength":
-						int minLength = -1;
-						if (int.TryParse(value, out minLength))
-							searchOptions.MinimumPathLength = minLength;
-						break;
-					case "MaxLength":
-						int maxLength = -1;
-						if (int.TryParse(value, out maxLength))
-							searchOptions.MaximumPathLength = maxLength;
-						break;
-					case "Output":
-						_output = value;
-						break;
-				}
-			}
-		}
 
 		/// <summary>
 		/// Prints the acceptable command line arguments.

--- a/src/PathLengthChecker/Program.cs
+++ b/src/PathLengthChecker/Program.cs
@@ -42,7 +42,7 @@ namespace PathLengthChecker
 				// Write any errors that occurred.
 				Console.Error.WriteLine(ex);
 				Console.Error.WriteLine();
-				PrintUsage();
+				Console.Error.WriteLine(ArgumentParser.ArgumentUsage);
 			}
 			finally
 			{
@@ -53,22 +53,6 @@ namespace PathLengthChecker
 		}
 
 
-		/// <summary>
-		/// Prints the acceptable command line arguments.
-		/// </summary>
-		private static void PrintUsage()
-		{
-			Console.Error.WriteLine("Parameters and example:");
-			Console.Error.WriteLine("RootDirectory= | Path to the directory to search through and list the paths of. Required.");
-			Console.Error.WriteLine("RootDirectoryReplacement=[null] | Path to replace the Root Directory with in the returned results. Specify 'null' to not replace the Root Directory. Default is null.");
-			Console.Error.WriteLine("SearchOption=[TopDirectory|All] | Specifies whether sub-directories should be searched or not. Default is All.");
-			Console.Error.WriteLine("TypesToInclude=[OnlyFiles|OnlyDirectories|All] | Specifies what types of paths should be returned in the results; files, directories, or both. Default is All.");
-			Console.Error.WriteLine("SearchPattern= | The pattern to match files against. '*' is a wildcard character. Default is '*' to match against everything.");
-			Console.Error.WriteLine("MinLength= | An integer indicating the minimum length that a path must contain in order to be returned in the results. Default is -1 to ignore this flag.");
-			Console.Error.WriteLine("MaxLength= | An integer indicating the maximum length that a path may have in order to be returned in the results. Default is -1 to ignore this flag.");
-			Console.Error.WriteLine("Output=[MinLength|MaxLength|All] | Indicates if you just want the Min/Max path length to be outputted, or if you want all of the paths to be outputted. Default is All.");
-			Console.Error.WriteLine();
-			Console.Error.WriteLine("Example: PathLengthChecker.exe RootDirectory=\"C:\\MyDir\" TypesToInclude=OnlyFiles SearchPattern=*FindThis* MinLength=25");
-		}
+		
 	}
 }

--- a/src/PathLengthCheckerGUI/App.xaml.cs
+++ b/src/PathLengthCheckerGUI/App.xaml.cs
@@ -24,10 +24,14 @@ namespace PathLengthCheckerGUI
 			var mainWindow = new MainWindow();
 
 			// If a directory was drag-and-dropped onto the GUI executable, launch with the app searching the given directory.
-			if (e.Args.Length > 0 && Directory.Exists(e.Args[0]))
+			if (e.Args.Length == 1 && Directory.Exists(e.Args[0]))
 			{
 				mainWindow.txtRootDirectory.Text = e.Args[0];
 				mainWindow.btnGetPathLengths.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+			}
+			else if (e.Args.Length > 1)
+			{
+				mainWindow.argSearchOptions = PathLengthChecker.ArgumentParser.ParseArgs(e.Args);
 			}
 
 			mainWindow.Show();

--- a/src/PathLengthCheckerGUI/App.xaml.cs
+++ b/src/PathLengthCheckerGUI/App.xaml.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using PathLengthChecker;
 
 namespace PathLengthCheckerGUI
 {
@@ -29,9 +30,26 @@ namespace PathLengthCheckerGUI
 				mainWindow.txtRootDirectory.Text = e.Args[0];
 				mainWindow.btnGetPathLengths.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
 			}
-			else if (e.Args.Length > 1)
+			else if (e.Args.Length >= 1)
 			{
-				mainWindow.argSearchOptions = PathLengthChecker.ArgumentParser.ParseArgs(e.Args);
+				try
+				{
+					var searchOptions = PathLengthChecker.ArgumentParser.ParseArgs(e.Args);
+					mainWindow.SetUIControlsFromSearchOptions(searchOptions);
+
+					// Only start the search if a root dir was specified
+					if (!String.IsNullOrEmpty(searchOptions?.RootDirectory))
+					{
+						mainWindow.btnGetPathLengths.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+					}
+				}
+				catch (ArgumentException ex)
+				{
+					string title = "Incorrect arguments";
+					string message = "Incorrectly-formatted arguments were passed to the program.\n\n";
+					message += ex.Message + "\n\n" + PathLengthChecker.ArgumentParser.ArgumentUsage;
+					MessageBox.Show(message, title);
+				}
 			}
 
 			mainWindow.Show();

--- a/src/PathLengthCheckerGUI/MainWindow.xaml.cs
+++ b/src/PathLengthCheckerGUI/MainWindow.xaml.cs
@@ -42,8 +42,6 @@ namespace PathLengthCheckerGUI
 		private DateTime _timePathSearchingStarted = DateTime.MinValue;
 		private CancellationTokenSource _searchCancellationTokenSource = new CancellationTokenSource();
 
-		internal PathLengthSearchOptions argSearchOptions = null;
-
 		public MainWindow()
 		{
 			InitializeComponent();
@@ -192,7 +190,7 @@ namespace PathLengthCheckerGUI
 				rootDirectoryReplacement = null;
 
 			// Build the options to search with.
-			var searchOptions = this.argSearchOptions ?? new PathLengthSearchOptions()
+			var searchOptions = new PathLengthSearchOptions()
 			{
 				RootDirectory = rootDirectory,
 				SearchPattern = searchPattern,
@@ -341,6 +339,26 @@ namespace PathLengthCheckerGUI
 			{
 				Process.Start(directoryPath);
 			}
+		}
+
+		/// <summary>
+		/// Sets the state of UI controls based on the provided search options
+		/// </summary>
+		protected internal void SetUIControlsFromSearchOptions(PathLengthSearchOptions argSearchOptions)
+		{
+			txtRootDirectory.Text = argSearchOptions.RootDirectory;
+			txtSearchPattern.Text = argSearchOptions.SearchPattern;
+			chkIncludeSubdirectories.IsChecked = argSearchOptions.SearchOption == SearchOption.AllDirectories;
+			cmbTypesToInclude.SelectedValue = argSearchOptions.TypesToGet;
+
+			if (!String.IsNullOrEmpty(argSearchOptions.RootDirectoryReplacement))
+			{
+				txtReplaceRootDirectory.Text = argSearchOptions.RootDirectoryReplacement;
+				chkReplaceRootDirectory.IsChecked = true;
+			}
+
+			numMinPathLength.Value = argSearchOptions.MinimumPathLength;
+			numMaxPathLength.Value = argSearchOptions.MaximumPathLength;
 		}
 	}
 }

--- a/src/PathLengthCheckerGUI/MainWindow.xaml.cs
+++ b/src/PathLengthCheckerGUI/MainWindow.xaml.cs
@@ -42,6 +42,8 @@ namespace PathLengthCheckerGUI
 		private DateTime _timePathSearchingStarted = DateTime.MinValue;
 		private CancellationTokenSource _searchCancellationTokenSource = new CancellationTokenSource();
 
+		internal PathLengthSearchOptions argSearchOptions = null;
+
 		public MainWindow()
 		{
 			InitializeComponent();
@@ -190,7 +192,7 @@ namespace PathLengthCheckerGUI
 				rootDirectoryReplacement = null;
 
 			// Build the options to search with.
-			var searchOptions = new PathLengthSearchOptions()
+			var searchOptions = this.argSearchOptions ?? new PathLengthSearchOptions()
 			{
 				RootDirectory = rootDirectory,
 				SearchPattern = searchPattern,


### PR DESCRIPTION
- All arguments supported by the console application are now supported by the GUI. For example, to check some of the shorter System namespace directories in your GAC:
`PathLengthCheckerGUI.exe RootDirectory=C:\Windows\Microsoft.NET\ RootDirectoryReplacement=D:\ SearchOption=All TypesToInclude=OnlyDirectories SearchPattern=System.* MinLength=30 MaxLength=40 Output=All`
- The GUI will also display the same argument usage text as the console application if incorrect arguments are provided.
- Still supports the root directory argument alone (e.g. via dropping a folder onto PathLengthCheckerGUI.exe as in PR #40) or via the newly-supported `RootDirectory` parameter. Using either results in the search running using defaults for everything else. For example:
  - Directory alone: `PathLengthCheckerGUI.exe C:\path\to\root`
  - RootDirectory parameter: `PathLengthCheckerGUI.exe RootDirectory=C:\path\to\root`
- Moved argument parsing and usage info text into ArgumentParser.cs to allow both to be used from either the console application or the GUI.
- Changed OutputType to a property of PathLengthSearchOptions (rather than just being a string in Program.cs) so the GUI can use it too.