### PR TITLE
AllowUrlEncodingOfPaths

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.11.0 - February 20, 2021
+
+Features:
+
+- Add new URL Encode Paths option for the both the GUI and command line app.
+- Reset Options button now also clears out grid sorting, since there's no native way to do with using the mouse or keyboard.
+- Update UI to group Search Options and Replacement Options separately.
+
 ## v1.10.0 - February 20, 2021
 
 Features:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -15,7 +15,7 @@ variables:
   buildConfiguration: 'Release'
   appBinariesDirectory: 'src\PathLengthCheckerGUI\bin\$(buildConfiguration)'
 
-  version.MajorMinor: '1.10' # Manually adjust the version number as needed for semantic versioning. Revision is auto-incremented.
+  version.MajorMinor: '1.11' # Manually adjust the version number as needed for semantic versioning. Revision is auto-incremented.
   version.Revision: $[counter(variables['version.MajorMinor'], 0)]
   versionNumber: '$(version.MajorMinor).$(version.Revision)'
 

--- a/src/PathLengthChecker/ArgumentParser.cs
+++ b/src/PathLengthChecker/ArgumentParser.cs
@@ -18,6 +18,7 @@ namespace PathLengthChecker
 			"SearchPattern= | The pattern to match files against. '*' is a wildcard character. Default is '*' to match against everything.\n" +
 			"MinLength= | An integer indicating the minimum length that a path must contain in order to be returned in the results. Default is -1 to ignore this flag.\n" +
 			"MaxLength= | An integer indicating the maximum length that a path may have in order to be returned in the results. Default is -1 to ignore this flag.\n" +
+			"UrlEncodePaths=[True|False] | If true the paths returned will be URL encoded. e.g. Spaces will be replaced with %20, backslashes with %5C, etc. Default is false.\n" +
 			"Output=[MinLength|MaxLength|All] | Indicates if you just want the Min/Max path length to be outputted, or if you want all of the paths to be outputted. Default is All.\n" +
 			"\n" +
 			"Example: PathLengthChecker.exe RootDirectory=\"C:\\MyDir\" TypesToInclude=OnlyFiles SearchPattern=*FindThis* MinLength=25";
@@ -75,6 +76,10 @@ namespace PathLengthChecker
 						int maxLength = -1;
 						if (int.TryParse(value, out maxLength))
 							searchOptions.MaximumPathLength = maxLength;
+						break;
+					case "UrlEncodePaths":
+						if (string.Equals(value, "True", StringComparison.OrdinalIgnoreCase))
+							searchOptions.UrlEncodePaths = true;
 						break;
 					case "Output":
 						OutputTypes outputType = OutputTypes.Paths;

--- a/src/PathLengthChecker/PathLengthChecker.csproj
+++ b/src/PathLengthChecker/PathLengthChecker.csproj
@@ -39,6 +39,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Transactions" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/PathLengthChecker/PathLengthChecker.csproj
+++ b/src/PathLengthChecker/PathLengthChecker.csproj
@@ -39,7 +39,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Transactions" />
-    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/PathLengthChecker/PathRetriever.cs
+++ b/src/PathLengthChecker/PathRetriever.cs
@@ -39,7 +39,7 @@ namespace PathLengthChecker
 
 				var transformedPath = path;
 				if (searchOptions.UrlEncodePaths)
-					transformedPath = System.Web.HttpUtility.UrlEncode(path);
+					transformedPath = System.Uri.EscapeDataString(path);
 
 				if (searchOptions.RootDirectoryReplacement == null)
 					yield return transformedPath;

--- a/src/PathLengthChecker/PathRetriever.cs
+++ b/src/PathLengthChecker/PathRetriever.cs
@@ -37,10 +37,14 @@ namespace PathLengthChecker
 				if (cancellationToken.IsCancellationRequested)
 					yield break;
 
+				var transformedPath = path;
+				if (searchOptions.UrlEncodePaths)
+					transformedPath = System.Web.HttpUtility.UrlEncode(path);
+
 				if (searchOptions.RootDirectoryReplacement == null)
-					yield return path;
+					yield return transformedPath;
 				else
-					yield return path.Replace(searchOptions.RootDirectory, searchOptions.RootDirectoryReplacement);
+					yield return transformedPath.Replace(searchOptions.RootDirectory, searchOptions.RootDirectoryReplacement);
 			}
 		}
 

--- a/src/PathLengthChecker/PathSearchOptions.cs
+++ b/src/PathLengthChecker/PathSearchOptions.cs
@@ -32,5 +32,10 @@ namespace PathLengthChecker
 		/// Specify null to leave the original paths unmodified.
 		/// </summary>
 		public string RootDirectoryReplacement = null;
+
+		/// <summary>
+		/// If true the returned paths will be URL encoded, such as replacing spaces with "%20".
+		/// </summary>
+		public bool UrlEncodePaths = false;
 	}
 }

--- a/src/PathLengthCheckerGUI/MainWindow.xaml
+++ b/src/PathLengthCheckerGUI/MainWindow.xaml
@@ -132,20 +132,17 @@
 		</DockPanel>
 
 		<Grid Grid.Row="6">
-			<Grid.RowDefinitions>
-				<RowDefinition Height="Auto" />
-				<RowDefinition Height="Auto" />
-			</Grid.RowDefinitions>
 			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="20" />
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="5" />
 				<ColumnDefinition Width="*" />
 				<ColumnDefinition Width="40" />
 			</Grid.ColumnDefinitions>
 
-			<CheckBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Content="Replace the Starting Directory in the returned paths with:" Name="chkReplaceRootDirectory" IsChecked="{local:ApplicationSettingsBinding Path=SearchOption_ReplaceRootDirectory}" ToolTip="If this is not enabled, the Starting Directory will not be modified in the returned paths." />
+			<CheckBox Grid.Column="0" Content="Replace the Starting Directory in the returned paths with:" Name="chkReplaceRootDirectory" IsChecked="{local:ApplicationSettingsBinding Path=SearchOption_ReplaceRootDirectory}" ToolTip="If this is not enabled, the Starting Directory will not be modified in the returned paths." />
 
-			<TextBox Grid.Row="1" Grid.Column="1" Name="txtReplaceRootDirectory" Text="{local:ApplicationSettingsBinding Path=SearchOption_RootDirectoryReplacementText, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Stretch" ToolTip="The path to replace the Starting Directory with in the paths that are returned." IsEnabled="{Binding ElementName=chkReplaceRootDirectory, Path=IsChecked}" />
-			<Button Grid.Row="1" Grid.Column="2" Content="..."  Name="btnBrowseForReplaceRootDirectory" Click="btnBrowseForReplaceRootDirectory_Click" ToolTip="Browse for a path to replace the Starting Directory path with." IsEnabled="{Binding ElementName=chkReplaceRootDirectory, Path=IsChecked}" />
+			<TextBox Grid.Column="2" Name="txtReplaceRootDirectory" Text="{local:ApplicationSettingsBinding Path=SearchOption_RootDirectoryReplacementText, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Stretch" ToolTip="The path to replace the Starting Directory with in the paths that are returned." IsEnabled="{Binding ElementName=chkReplaceRootDirectory, Path=IsChecked}" />
+			<Button Grid.Column="3" Content="..."  Name="btnBrowseForReplaceRootDirectory" Click="btnBrowseForReplaceRootDirectory_Click" ToolTip="Browse for a path to replace the Starting Directory path with." IsEnabled="{Binding ElementName=chkReplaceRootDirectory, Path=IsChecked}" />
 		</Grid>
 
 		<Grid Grid.Row="8">

--- a/src/PathLengthCheckerGUI/MainWindow.xaml
+++ b/src/PathLengthCheckerGUI/MainWindow.xaml
@@ -39,10 +39,6 @@
 			<RowDefinition Height="5"/>
 			<RowDefinition Height="Auto"/>
 			<RowDefinition Height="5"/>
-			<RowDefinition Height="Auto"/>
-			<RowDefinition Height="5"/>
-			<RowDefinition Height="Auto"/>
-			<RowDefinition Height="5"/>
 			<RowDefinition Height="*"/>
 			<RowDefinition Height="5"/>
 			<RowDefinition Height="Auto"/>
@@ -50,102 +46,130 @@
 			<RowDefinition Height="Auto"/>
 		</Grid.RowDefinitions>
 
-		<Grid Grid.Row="0">
-			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="Auto" />
-				<ColumnDefinition Width="5" />
-				<ColumnDefinition Width="*" />
-				<ColumnDefinition Width="40" />
-			</Grid.ColumnDefinitions>
+		<GroupBox Grid.Row="0" Header="Path Search Options">
+			<Grid>
+				<Grid.RowDefinitions>
+					<RowDefinition Height="Auto"/>
+					<RowDefinition Height="5"/>
+					<RowDefinition Height="Auto"/>
+					<RowDefinition Height="5"/>
+					<RowDefinition Height="Auto"/>
+					<RowDefinition Height="5"/>
+				</Grid.RowDefinitions>
 
-			<TextBlock Grid.Column="0" Text="Starting Directory:" ToolTip="The root directory to look for files and/or directories in." />
-			<TextBox Grid.Column="2" Name="txtRootDirectory" Text="{local:ApplicationSettingsBinding Path=SearchOption_RootDirectory, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Stretch" ToolTip="The directory to look for files and/or directories in." />
-			<Button Grid.Column="3" Content="..." x:Name="btnBrowseForRootDirectory" Click="btnBrowseForRootDirectory_Click" ToolTip="Browse for a folder to search in." />
-		</Grid>
+				<Grid Grid.Row="0">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto" />
+						<ColumnDefinition Width="5" />
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="40" />
+					</Grid.ColumnDefinitions>
 
-		<Grid Grid.Row="2">
-			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="Auto"/>
-				<ColumnDefinition Width="120"/>
-				<ColumnDefinition Width="*"/>
-				<ColumnDefinition Width="Auto"/>
-				<ColumnDefinition Width="*"/>
-				<ColumnDefinition Width="Auto"/>
-				<ColumnDefinition Width="Auto"/>
-				<ColumnDefinition Width="*"/>
-				<ColumnDefinition Width="Auto"/>
-				<ColumnDefinition Width="Auto"/>
-				<ColumnDefinition Width="*"/>
-			</Grid.ColumnDefinitions>
+					<TextBlock Grid.Column="0" Text="Starting Directory:" ToolTip="The root directory to look for files and/or directories in." />
+					<TextBox Grid.Column="2" Name="txtRootDirectory" Text="{local:ApplicationSettingsBinding Path=SearchOption_RootDirectory, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Stretch" ToolTip="The directory to look for files and/or directories in." />
+					<Button Grid.Column="3" Content="..." x:Name="btnBrowseForRootDirectory" Click="btnBrowseForRootDirectory_Click" ToolTip="Browse for a folder to search in." />
+				</Grid>
 
-			<TextBlock Grid.Column="0" Text="Include:" Margin="0,0,5,0" VerticalAlignment="Center"  ToolTip="The file system types to find and return the path length of." />
-			<ComboBox Grid.Column="1" Name="cmbTypesToInclude" ItemsSource="{Binding Source={StaticResource FileSystemTypesEnumValues}}" SelectedValue="{local:ApplicationSettingsBinding Path=SearchOption_FileSystemTypesToInclude}" ToolTip="The file system types to find and return the path length of." />
+				<Grid Grid.Row="2">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto"/>
+						<ColumnDefinition Width="120"/>
+						<ColumnDefinition Width="*"/>
+						<ColumnDefinition Width="Auto"/>
+						<ColumnDefinition Width="*"/>
+						<ColumnDefinition Width="Auto"/>
+						<ColumnDefinition Width="Auto"/>
+						<ColumnDefinition Width="*"/>
+						<ColumnDefinition Width="Auto"/>
+						<ColumnDefinition Width="Auto"/>
+						<ColumnDefinition Width="*"/>
+					</Grid.ColumnDefinitions>
 
-			<CheckBox Grid.Column="3" Content="Include Subdirectories" Name="chkIncludeSubdirectories" IsChecked="{local:ApplicationSettingsBinding Path=SearchOption_IncludeSubdirectories}" VerticalAlignment="Center" ToolTip="If enabled it will search for files/directories in all subdirectories of the Starting Directory." />
+					<TextBlock Grid.Column="0" Text="Include:" Margin="0,0,5,0" VerticalAlignment="Center"  ToolTip="The file system types to find and return the path length of." />
+					<ComboBox Grid.Column="1" Name="cmbTypesToInclude" ItemsSource="{Binding Source={StaticResource FileSystemTypesEnumValues}}" SelectedValue="{local:ApplicationSettingsBinding Path=SearchOption_FileSystemTypesToInclude}" ToolTip="The file system types to find and return the path length of." />
 
-			<TextBlock Grid.Column="5" Margin="0,0,5,0" Text="Min Path Length:" VerticalAlignment="Center">
-				<TextBlock.ToolTip>
-					<TextBlock>
-						Only paths with this many or more characters will be returned in the search results.
-						<LineBreak />
-						Use 260 to identify long paths that Windows may have trouble handling.
-						<LineBreak />
-						Use 0 to not filter any paths by minimum length.
-					</TextBlock>
-				</TextBlock.ToolTip>
-			</TextBlock>
-			<extToolkit:IntegerUpDown Grid.Column="6" Name="numMinPathLength" Value="{local:ApplicationSettingsBinding Path=SearchOption_MinPathLength}" DefaultValue="0" Minimum="0" Maximum="999999" MinWidth="50">
-				<extToolkit:IntegerUpDown.ToolTip>
-					<TextBlock>
-						Only paths with this many or more characters will be returned in the search results.
-						<LineBreak />
-						Use 260 to identify long paths that Windows may have trouble handling.
-						<LineBreak />
-						Use 0 to not filter any paths by minimum length.
-					</TextBlock>
-				</extToolkit:IntegerUpDown.ToolTip>
-			</extToolkit:IntegerUpDown>
+					<CheckBox Grid.Column="3" Content="Include Subdirectories" Name="chkIncludeSubdirectories" IsChecked="{local:ApplicationSettingsBinding Path=SearchOption_IncludeSubdirectories}" VerticalAlignment="Center" ToolTip="If enabled it will search for files/directories in all subdirectories of the Starting Directory." />
 
-			<TextBlock Grid.Column="8" Margin="0,0,5,0" Text="Max Path Length:" VerticalAlignment="Center">
-				<TextBlock.ToolTip>
-					<TextBlock>
-						Only paths with this many or less characters will be returned in the search results.
-						<LineBreak />
-						Use a large value like 999999 to not filter any paths by maximum length.
-					</TextBlock>
-				</TextBlock.ToolTip>
-			</TextBlock>
-			<extToolkit:IntegerUpDown Grid.Column="9" Name="numMaxPathLength" Value="{local:ApplicationSettingsBinding Path=SearchOption_MaxPathLength}" DefaultValue="0" Minimum="0" Maximum="999999" MinWidth="50">
-				<extToolkit:IntegerUpDown.ToolTip>
-					<TextBlock>
-						Only paths with this many or less characters will be returned in the search results.
-						<LineBreak />
-						Use a large value like 999999 to not filter any paths by maximum length.
-					</TextBlock>
-				</extToolkit:IntegerUpDown.ToolTip>
-			</extToolkit:IntegerUpDown>
-		</Grid>
+					<TextBlock Grid.Column="5" Margin="0,0,5,0" Text="Min Path Length:" VerticalAlignment="Center">
+						<TextBlock.ToolTip>
+							<TextBlock>
+							Only paths with this many or more characters will be returned in the search results.
+							<LineBreak />
+							Use 260 to identify long paths that Windows may have trouble handling.
+							<LineBreak />
+							Use 0 to not filter any paths by minimum length.
+							</TextBlock>
+						</TextBlock.ToolTip>
+				</TextBlock>
+					<extToolkit:IntegerUpDown Grid.Column="6" Name="numMinPathLength" Value="{local:ApplicationSettingsBinding Path=SearchOption_MinPathLength}" DefaultValue="0" Minimum="0" Maximum="999999" MinWidth="50">
+						<extToolkit:IntegerUpDown.ToolTip>
+							<TextBlock>
+							Only paths with this many or more characters will be returned in the search results.
+							<LineBreak />
+							Use 260 to identify long paths that Windows may have trouble handling.
+							<LineBreak />
+							Use 0 to not filter any paths by minimum length.
+							</TextBlock>
+						</extToolkit:IntegerUpDown.ToolTip>
+					</extToolkit:IntegerUpDown>
 
-		<DockPanel Grid.Row="4">
-			<TextBlock Text="Search Pattern:" Margin="0,0,5,0" ToolTip="Only files/directories that match the given pattern will be returned." />
-			<TextBox Name="txtSearchPattern" Text="{local:ApplicationSettingsBinding Path=SearchOption_SearchPattern, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Stretch" ToolTip="Only files/directories that match the given pattern will be returned. The * is a wildcard." />
-		</DockPanel>
+					<TextBlock Grid.Column="8" Margin="0,0,5,0" Text="Max Path Length:" VerticalAlignment="Center">
+						<TextBlock.ToolTip>
+							<TextBlock>
+							Only paths with this many or less characters will be returned in the search results.
+							<LineBreak />
+							Use a large value like 999999 to not filter any paths by maximum length.
+							</TextBlock>
+						</TextBlock.ToolTip>
+				</TextBlock>
+					<extToolkit:IntegerUpDown Grid.Column="9" Name="numMaxPathLength" Value="{local:ApplicationSettingsBinding Path=SearchOption_MaxPathLength}" DefaultValue="0" Minimum="0" Maximum="999999" MinWidth="50">
+						<extToolkit:IntegerUpDown.ToolTip>
+							<TextBlock>
+							Only paths with this many or less characters will be returned in the search results.
+							<LineBreak />
+							Use a large value like 999999 to not filter any paths by maximum length.
+							</TextBlock>
+						</extToolkit:IntegerUpDown.ToolTip>
+					</extToolkit:IntegerUpDown>
+				</Grid>
 
-		<Grid Grid.Row="6">
-			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="Auto" />
-				<ColumnDefinition Width="5" />
-				<ColumnDefinition Width="*" />
-				<ColumnDefinition Width="40" />
-			</Grid.ColumnDefinitions>
+				<DockPanel Grid.Row="4">
+					<TextBlock Text="Search Pattern:" Margin="0,0,5,0" ToolTip="Only files/directories that match the given pattern will be returned." />
+					<TextBox Name="txtSearchPattern" Text="{local:ApplicationSettingsBinding Path=SearchOption_SearchPattern, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Stretch" ToolTip="Only files/directories that match the given pattern will be returned. The * is a wildcard." />
+				</DockPanel>
+			</Grid>
+		</GroupBox>
 
-			<CheckBox Grid.Column="0" Content="Replace the Starting Directory in the returned paths with:" Name="chkReplaceRootDirectory" IsChecked="{local:ApplicationSettingsBinding Path=SearchOption_ReplaceRootDirectory}" ToolTip="If this is not enabled, the Starting Directory will not be modified in the returned paths." />
+		<GroupBox Grid.Row="2" Header="Path Replacement Options">
+			<Grid>
+				<Grid.RowDefinitions>
+					<RowDefinition Height="Auto"/>
+					<RowDefinition Height="5"/>
+					<RowDefinition Height="Auto"/>
+					<RowDefinition Height="5"/>
+				</Grid.RowDefinitions>
 
-			<TextBox Grid.Column="2" Name="txtReplaceRootDirectory" Text="{local:ApplicationSettingsBinding Path=SearchOption_RootDirectoryReplacementText, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Stretch" ToolTip="The path to replace the Starting Directory with in the paths that are returned." IsEnabled="{Binding ElementName=chkReplaceRootDirectory, Path=IsChecked}" />
-			<Button Grid.Column="3" Content="..."  Name="btnBrowseForReplaceRootDirectory" Click="btnBrowseForReplaceRootDirectory_Click" ToolTip="Browse for a path to replace the Starting Directory path with." IsEnabled="{Binding ElementName=chkReplaceRootDirectory, Path=IsChecked}" />
-		</Grid>
+				<Grid Grid.Row="0">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto" />
+						<ColumnDefinition Width="5" />
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="40" />
+					</Grid.ColumnDefinitions>
 
-		<Grid Grid.Row="8">
+					<CheckBox Grid.Column="0" Content="Replace the Starting Directory in the returned paths with:" Name="chkReplaceRootDirectory" IsChecked="{local:ApplicationSettingsBinding Path=SearchOption_ReplaceRootDirectory}" ToolTip="If this is not enabled, the Starting Directory will not be modified in the returned paths." />
+
+					<TextBox Grid.Column="2" Name="txtReplaceRootDirectory" Text="{local:ApplicationSettingsBinding Path=SearchOption_RootDirectoryReplacementText, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Stretch" ToolTip="The path to replace the Starting Directory with in the paths that are returned." IsEnabled="{Binding ElementName=chkReplaceRootDirectory, Path=IsChecked}" />
+					<Button Grid.Column="3" Content="..."  Name="btnBrowseForReplaceRootDirectory" Click="btnBrowseForReplaceRootDirectory_Click" ToolTip="Browse for a path to replace the Starting Directory path with." IsEnabled="{Binding ElementName=chkReplaceRootDirectory, Path=IsChecked}" />
+				</Grid>
+
+				<DockPanel Grid.Row="2">
+					<CheckBox Name="chkUrlEncodePaths" Content="Url encode paths" IsChecked="{local:ApplicationSettingsBinding Path=SearchOption_UrlEncodePaths}" VerticalAlignment="Center" ToolTip="If enabled all paths will be URL encoded. e.g. spaces will be replaced with %20." />
+				</DockPanel>
+			</Grid>
+		</GroupBox>
+
+		<Grid Grid.Row="4">
 			<Grid.ColumnDefinitions>
 				<ColumnDefinition Width="10" />
 				<ColumnDefinition Width="*" />
@@ -155,11 +179,11 @@
 			<Button Grid.Column="1" Content="Get Path Lengths..." Name="btnGetPathLengths" FontSize="40" Click="btnGetPathLengths_Click" IsDefault="True" />
 			<Button Grid.Column="1" Content="Cancel retrieving paths" Name="btnCancelGetPathLengths" FontSize="40" Click="btnCancelGetPathLengths_Click" Visibility="Collapsed" />
 			<Button Grid.Column="3" Name="btnResetSearchOptions" Margin="0,10,0,10" ToolTip="Reset all of the search fields to their default values." Click="btnResetSearchOptions_Click">
-				<TextBlock TextWrapping="Wrap" TextAlignment="Center">Reset search options</TextBlock>
+				<TextBlock TextWrapping="Wrap" TextAlignment="Center">Reset all options</TextBlock>
 			</Button>
 		</Grid>
 
-		<DataGrid Grid.Row="10" AutoGenerateColumns="False" Name="dgPaths" IsReadOnly="True" IsTabStop="False" Grid.ColumnSpan="4" LoadingRow="dgPaths_LoadingRow" ItemsSource="{Binding Source={StaticResource PathsCollectionViewSource}}" SelectedItem="{Binding Path=SelectedPath, Mode=TwoWay}" FontFamily="Courier New" CanUserSortColumns="True">
+		<DataGrid Grid.Row="6" AutoGenerateColumns="False" Name="dgPaths" IsReadOnly="True" IsTabStop="False" Grid.ColumnSpan="4" LoadingRow="dgPaths_LoadingRow" ItemsSource="{Binding Source={StaticResource PathsCollectionViewSource}}" SelectedItem="{Binding Path=SelectedPath, Mode=TwoWay}" FontFamily="Courier New" CanUserSortColumns="True">
 			<DataGrid.Columns>
 				<DataGridTextColumn Header="Length" IsReadOnly="True" Binding="{Binding Path=Length}" SortMemberPath="Length" />
 				<DataGridTextColumn Header="Path" IsReadOnly="True" Binding="{Binding Path=Path}" SortMemberPath="Path" />
@@ -173,10 +197,10 @@
 			</DataGrid.ContextMenu>
 		</DataGrid>
 
-		<TextBlock Grid.Row="12" Name="txtNumberOfPaths" Text="" />
-		<TextBlock Grid.Row="14" Name="txtMinAndMaxPathLengths" Text="" />
+		<TextBlock Grid.Row="8" Name="txtNumberOfPaths" Text="" />
+		<TextBlock Grid.Row="10" Name="txtMinAndMaxPathLengths" Text="" />
 
-		<StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="12" Grid.RowSpan="4">
+		<StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="8" Grid.RowSpan="4">
 			<extToolkit:SplitButton x:Name="splitbtnCopyToClipboard" Content="Copy Paths to Clipboard" Click="splitbtnCopyToClipboard_Click" Width="350">
 				<extToolkit:SplitButton.DropDownContent>
 					<StackPanel Orientation="Vertical" Width="345">

--- a/src/PathLengthCheckerGUI/MainWindow.xaml
+++ b/src/PathLengthCheckerGUI/MainWindow.xaml
@@ -180,7 +180,7 @@
 			</Grid.ColumnDefinitions>
 			<Button Grid.Column="1" Content="Get Path Lengths..." Name="btnGetPathLengths" FontSize="40" Click="btnGetPathLengths_Click" IsDefault="True" />
 			<Button Grid.Column="1" Content="Cancel retrieving paths" Name="btnCancelGetPathLengths" FontSize="40" Click="btnCancelGetPathLengths_Click" Visibility="Collapsed" />
-			<Button Grid.Column="3" Name="btnResetSearchOptions" Margin="0,10,0,10" ToolTip="Reset all of the search fields to their default values." Click="btnResetSearchOptions_Click">
+			<Button Grid.Column="3" Name="btnResetAllOptions" Margin="0,10,0,10" ToolTip="Reset all of the search and replacement fields to their default values, and clears sorting on the results grid." Click="btnResetAllOptions_Click">
 				<TextBlock TextWrapping="Wrap" TextAlignment="Center">Reset all options</TextBlock>
 			</Button>
 		</Grid>

--- a/src/PathLengthCheckerGUI/MainWindow.xaml
+++ b/src/PathLengthCheckerGUI/MainWindow.xaml
@@ -49,6 +49,7 @@
 		<GroupBox Grid.Row="0" Header="Path Search Options">
 			<Grid>
 				<Grid.RowDefinitions>
+					<RowDefinition Height="5"/>
 					<RowDefinition Height="Auto"/>
 					<RowDefinition Height="5"/>
 					<RowDefinition Height="Auto"/>
@@ -57,7 +58,7 @@
 					<RowDefinition Height="5"/>
 				</Grid.RowDefinitions>
 
-				<Grid Grid.Row="0">
+				<Grid Grid.Row="1">
 					<Grid.ColumnDefinitions>
 						<ColumnDefinition Width="Auto" />
 						<ColumnDefinition Width="5" />
@@ -70,7 +71,7 @@
 					<Button Grid.Column="3" Content="..." x:Name="btnBrowseForRootDirectory" Click="btnBrowseForRootDirectory_Click" ToolTip="Browse for a folder to search in." />
 				</Grid>
 
-				<Grid Grid.Row="2">
+				<Grid Grid.Row="3">
 					<Grid.ColumnDefinitions>
 						<ColumnDefinition Width="Auto"/>
 						<ColumnDefinition Width="120"/>
@@ -133,7 +134,7 @@
 					</extToolkit:IntegerUpDown>
 				</Grid>
 
-				<DockPanel Grid.Row="4">
+				<DockPanel Grid.Row="5">
 					<TextBlock Text="Search Pattern:" Margin="0,0,5,0" ToolTip="Only files/directories that match the given pattern will be returned." />
 					<TextBox Name="txtSearchPattern" Text="{local:ApplicationSettingsBinding Path=SearchOption_SearchPattern, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Stretch" ToolTip="Only files/directories that match the given pattern will be returned. The * is a wildcard." />
 				</DockPanel>
@@ -143,13 +144,14 @@
 		<GroupBox Grid.Row="2" Header="Path Replacement Options">
 			<Grid>
 				<Grid.RowDefinitions>
+					<RowDefinition Height="5"/>
 					<RowDefinition Height="Auto"/>
 					<RowDefinition Height="5"/>
 					<RowDefinition Height="Auto"/>
 					<RowDefinition Height="5"/>
 				</Grid.RowDefinitions>
 
-				<Grid Grid.Row="0">
+				<Grid Grid.Row="1">
 					<Grid.ColumnDefinitions>
 						<ColumnDefinition Width="Auto" />
 						<ColumnDefinition Width="5" />
@@ -163,8 +165,8 @@
 					<Button Grid.Column="3" Content="..."  Name="btnBrowseForReplaceRootDirectory" Click="btnBrowseForReplaceRootDirectory_Click" ToolTip="Browse for a path to replace the Starting Directory path with." IsEnabled="{Binding ElementName=chkReplaceRootDirectory, Path=IsChecked}" />
 				</Grid>
 
-				<DockPanel Grid.Row="2">
-					<CheckBox Name="chkUrlEncodePaths" Content="Url encode paths" IsChecked="{local:ApplicationSettingsBinding Path=SearchOption_UrlEncodePaths}" VerticalAlignment="Center" ToolTip="If enabled all paths will be URL encoded. e.g. spaces will be replaced with %20." />
+				<DockPanel Grid.Row="3">
+					<CheckBox Name="chkUrlEncodePaths" Content="Url encode paths" IsChecked="{local:ApplicationSettingsBinding Path=SearchOption_UrlEncodePaths}" VerticalAlignment="Center" ToolTip="If enabled all paths will be URL encoded. e.g. Spaces will be replaced with %20, backslashes with %5C." />
 				</DockPanel>
 			</Grid>
 		</GroupBox>

--- a/src/PathLengthCheckerGUI/MainWindow.xaml
+++ b/src/PathLengthCheckerGUI/MainWindow.xaml
@@ -166,7 +166,7 @@
 				</Grid>
 
 				<DockPanel Grid.Row="3">
-					<CheckBox Name="chkUrlEncodePaths" Content="Url encode paths" IsChecked="{local:ApplicationSettingsBinding Path=SearchOption_UrlEncodePaths}" VerticalAlignment="Center" ToolTip="If enabled all paths will be URL encoded. e.g. Spaces will be replaced with %20, backslashes with %5C." />
+					<CheckBox Name="chkUrlEncodePaths" Content="Url encode paths" IsChecked="{local:ApplicationSettingsBinding Path=SearchOption_UrlEncodePaths}" VerticalAlignment="Center" ToolTip="If enabled all paths will be URL encoded. e.g. Spaces will be replaced with %20, backslashes with %5C, etc." />
 				</DockPanel>
 			</Grid>
 		</GroupBox>

--- a/src/PathLengthCheckerGUI/MainWindow.xaml.cs
+++ b/src/PathLengthCheckerGUI/MainWindow.xaml.cs
@@ -221,6 +221,7 @@ namespace PathLengthCheckerGUI
 				SearchOption = (chkIncludeSubdirectories.IsChecked ?? false) ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly,
 				TypesToGet = (FileSystemTypes)cmbTypesToInclude.SelectedValue,
 				RootDirectoryReplacement = rootDirectoryReplacement,
+				UrlEncodePaths = (chkUrlEncodePaths.IsChecked ?? false),
 				MinimumPathLength = minPathLength,
 				MaximumPathLength = maxPathLength
 			};
@@ -439,6 +440,7 @@ namespace PathLengthCheckerGUI
 				txtReplaceRootDirectory.Text = argSearchOptions.RootDirectoryReplacement;
 				chkReplaceRootDirectory.IsChecked = true;
 			}
+			chkUrlEncodePaths.IsChecked = argSearchOptions.UrlEncodePaths;
 
 			numMinPathLength.Value = argSearchOptions.MinimumPathLength;
 			numMaxPathLength.Value = argSearchOptions.MaximumPathLength;
@@ -464,6 +466,7 @@ namespace PathLengthCheckerGUI
 
 			txtReplaceRootDirectory.Text = string.Empty;
 			chkReplaceRootDirectory.IsChecked = false;
+			chkUrlEncodePaths.IsChecked = false;
 		}
 	}
 }

--- a/src/PathLengthCheckerGUI/MainWindow.xaml.cs
+++ b/src/PathLengthCheckerGUI/MainWindow.xaml.cs
@@ -446,9 +446,10 @@ namespace PathLengthCheckerGUI
 			numMaxPathLength.Value = argSearchOptions.MaximumPathLength;
 		}
 
-		private void btnResetSearchOptions_Click(object sender, RoutedEventArgs e)
+		private void btnResetAllOptions_Click(object sender, RoutedEventArgs e)
 		{
 			ResetAllUiSearchOptionsToDefaultValues();
+			ResetGridSorting();
 		}
 
 		private void ResetAllUiSearchOptionsToDefaultValues()
@@ -467,6 +468,11 @@ namespace PathLengthCheckerGUI
 			txtReplaceRootDirectory.Text = string.Empty;
 			chkReplaceRootDirectory.IsChecked = false;
 			chkUrlEncodePaths.IsChecked = false;
+		}
+
+		private void ResetGridSorting()
+		{
+			SetGridColumnSortDescriptions(Enumerable.Empty<SortDescription>());
 		}
 	}
 }

--- a/src/PathLengthCheckerGUI/Properties/Settings.Designer.cs
+++ b/src/PathLengthCheckerGUI/Properties/Settings.Designer.cs
@@ -189,5 +189,17 @@ namespace PathLengthCheckerGUI.Properties {
                 this["ResultsGridColumnSortDescriptionCollection"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool SearchOption_UrlEncodePaths {
+            get {
+                return ((bool)(this["SearchOption_UrlEncodePaths"]));
+            }
+            set {
+                this["SearchOption_UrlEncodePaths"] = value;
+            }
+        }
     }
 }

--- a/src/PathLengthCheckerGUI/Properties/Settings.settings
+++ b/src/PathLengthCheckerGUI/Properties/Settings.settings
@@ -44,5 +44,8 @@
     <Setting Name="ResultsGridColumnSortDescriptionCollection" Type="System.ComponentModel.SortDescriptionCollection" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="SearchOption_UrlEncodePaths" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/PathLengthCheckerGUI/app.config
+++ b/src/PathLengthCheckerGUI/app.config
@@ -46,6 +46,9 @@
             <setting name="SearchOption_RootDirectoryReplacementText" serializeAs="String">
                 <value />
             </setting>
+            <setting name="SearchOption_UrlEncodePaths" serializeAs="String">
+                <value>False</value>
+            </setting>
         </PathLengthCheckerGUI.Properties.Settings>
     </userSettings>
 </configuration>


### PR DESCRIPTION
Features:

- Add new URL Encode Paths option for the both the GUI and command line app.
- Reset Options button now also clears out grid sorting, since there's no native way to do with using the mouse or keyboard.
- Update UI to group Search Options and Replacement Options separately.