### PR TITLE
Change 'Url encode' to 'Percent-encode'

### DIFF
--- a/src/PathLengthCheckerGUI/MainWindow.xaml
+++ b/src/PathLengthCheckerGUI/MainWindow.xaml
@@ -166,7 +166,7 @@
 				</Grid>
 
 				<DockPanel Grid.Row="3">
-					<CheckBox Name="chkUrlEncodePaths" Content="Url encode paths" IsChecked="{local:ApplicationSettingsBinding Path=SearchOption_UrlEncodePaths}" VerticalAlignment="Center" ToolTip="If enabled all paths will be URL encoded. e.g. Spaces will be replaced with %20, backslashes with %5C, etc." />
+					<CheckBox Name="chkUrlEncodePaths" Content="Percent-encode paths" IsChecked="{local:ApplicationSettingsBinding Path=SearchOption_UrlEncodePaths}" VerticalAlignment="Center" ToolTip="If enabled all paths will be URL encoded. e.g. Spaces will be replaced with %20, backslashes with %5C, etc." />
 				</DockPanel>
 			</Grid>
 		</GroupBox>


### PR DESCRIPTION
Thank you for this helpful tool.  

At first, I found it a bit confusing that it had an option to URL-encode paths, as URLs and paths are based on different standards.  I think it will help to change this label to 'Percent-encode' as that is the term preferred by RFC 3986 as well as Wikipedia:  

RFC 3986  
https://datatracker.ietf.org/doc/html/rfc3986#page-12

Binary-to-text encoding - Wikipedia  
https://en.wikipedia.org/wiki/Binary-to-text_encoding

Percent-encoding - Wikipedia  
https://en.wikipedia.org/wiki/Percent-encoding